### PR TITLE
Feature/card block

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        php-versions: ['7.4']
+        php-versions: ['7.4', '8.1']
     steps:
       - uses: actions/checkout@v3
       - name: Setup PHP

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,30 @@
+name: Tests and linting
+
+on: push
+
+jobs:
+  kahlan:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        php-versions: ['7.4']
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: |
+          echo "::set-output name=dir::$(composer config cache-files-dir)"
+      - uses: actions/cache@v3
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+      - name: Install dependencies
+        run: composer install --no-interaction
+      - name: PHP CS fix
+        run: vendor/bin/php-cs-fixer fix --dry-run -v --diff

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -1,0 +1,8 @@
+<?php
+
+$finder = \PhpCsFixer\Finder::create()
+->exclude('vendor')
+->in(__DIR__);
+
+return \Dxw\PhpCsFixerConfig\Config::create()
+->setFinder($finder);

--- a/README.md
+++ b/README.md
@@ -1,1 +1,37 @@
 # GovPress Blocks
+
+A library of reusable blocks for use in GovPress projects.
+
+## How to use
+
+1. Install the package in your theme:
+   ```
+   composer require dxw/govpress-blocks
+   ```
+1. Use the factory to create the blocks you want to use, and pass them any configuration, e.g.
+   To create a card block with default config:
+   ```
+   \Dxw\GovPressBlocks\Factory::create('card');
+   ```
+   To create a card block that renders a custom template:
+   ```
+   \Dxw\GovPressBlocks\Factory::create('card', [
+     'template' => '\the\full\path\to\your\custom\template.php`
+   ]);
+   ```
+   For dxw projects, the recommended approach is to add this code to your theme's `app/di.php`, if the theme uses [Iguana](https://github.com/dxw/iguana).
+
+The available blocks are documented below.
+
+## Blocks
+
+### Card
+
+`\Dxw\GovPressBLocks\Factory::create('card', array $config)`
+
+Config options:
+
+```
+[
+    'template' => string $theFullPathToYourCustomCardTemplate
+]

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "kahlan/kahlan": "^5.2"
     },
     "require": {
-        "stoutlogic/acf-builder": "^1.12"
+        "stoutlogic/acf-builder": "^1.12",
+        "php": "^7.4||^8.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,13 @@
         }
     ],
     "license": "MIT",
+    "autoload": {
+        "psr-4": {
+            "Dxw\\GovPressBlocks\\": "src/"
+        }
+    },
     "require-dev": {
-        "dxw/php-cs-fixer-config": "^2.0"
-    }
+        "dxw/php-cs-fixer-config": "^2.0",
+        "kahlan/kahlan": "^5.2"
+    }   
 }

--- a/composer.json
+++ b/composer.json
@@ -17,5 +17,8 @@
     "require-dev": {
         "dxw/php-cs-fixer-config": "^2.0",
         "kahlan/kahlan": "^5.2"
-    }   
+    },
+    "require": {
+        "stoutlogic/acf-builder": "^1.12"
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -8,5 +8,8 @@
             "homepage": "https://www.dxw.com"
         }
     ],
-    "license": "MIT"
+    "license": "MIT",
+    "require-dev": {
+        "dxw/php-cs-fixer-config": "^2.0"
+    }
 }

--- a/spec/blocks/card.spec.php
+++ b/spec/blocks/card.spec.php
@@ -14,6 +14,17 @@ describe(\Dxw\GovPressBlocks\Blocks\Card::class, function () {
         expect($this->card)->toBeAnInstanceOf(\Dxw\GovPressBlocks\Blocks\iBlock::class);
     });
 
+    describe('->register()', function () {
+        it('adds the actions', function () {
+            allow('add_action')->toBeCalled();
+            expect('add_action')->toBeCalled()->times(2);
+            expect('add_action')->toBeCalled()->once()->with('acf/init', [$this->card, 'registerBlock']);
+            expect('add_action')->toBeCalled()->once()->with('acf/init', [$this->card, 'registerFields']);
+
+            $this->card->register();
+        });
+    });
+
     describe('->registerBlock()', function () {
         it('registers the card block', function () {
             allow('function_exists')->toBeCalled()->andReturn(true);

--- a/spec/blocks/card.spec.php
+++ b/spec/blocks/card.spec.php
@@ -1,0 +1,59 @@
+<?php
+
+use Kahlan\Plugin\Double;
+
+use function Kahlan\expect;
+
+describe(\Dxw\GovPressBlocks\Blocks\Card::class, function () {
+    beforeEach(function () {
+        $this->card = new \Dxw\GovPressBlocks\Blocks\Card([]);
+    });
+
+    it('implements the iBlock interface', function () {
+        expect($this->card)->toBeAnInstanceOf(\Dxw\GovPressBlocks\Blocks\iBlock::class);
+    });
+
+    describe('->registerBlock()', function () {
+        it('registers the card block', function () {
+            allow('function_exists')->toBeCalled()->andReturn(true);
+            allow('acf_register_block_type')->toBeCalled();
+            expect('acf_register_block_type')->toBeCalled()->once()->with(\Kahlan\Arg::toBeAn('array'));
+
+            $this->card->registerBlock();
+        });
+        it('does nothing if ACF is not activated', function () {
+            allow('function_exists')->toBeCalled()->andReturn(false);
+
+            $this->card->registerBlock();
+        });
+    });
+
+    describe('->registerFields()', function () {
+        it('registers the card fields', function () {
+            allow('function_exists')->toBeCalled()->andReturn(true);
+            $fieldsBuilderDouble = \Kahlan\Plugin\Double::instance();
+            allow('StoutLogic\AcfBuilder\FieldsBuilder')->toBe($fieldsBuilderDouble);
+            allow($fieldsBuilderDouble)->toReceive('build')->andReturn('built fields');
+            allow('acf_add_local_field_group')->toBeCalled();
+            expect('acf_add_local_field_group')->toBeCalled()->once()->with('built fields');
+    
+            $this->card->registerFields();
+        });
+        it('does nothing if ACF is not activated', function () {
+            allow('function_exists')->toBeCalled()->andReturn(false);
+
+            $this->card->registerFields();
+        });
+    });
+
+    describe('->render()', function () {
+        it('loads the default template', function () {
+            allow('dirname')->toBeCalled();
+            expect('dirname')->toBeCalled()->once()->with(\Kahlan\Arg::toBeA('string'), 2);
+            allow('load_template')->toBeCalled();
+            expect('load_template')->toBeCalled()->once();
+
+            $this->card->render();
+        });
+    });
+});

--- a/spec/blocks/card.spec.php
+++ b/spec/blocks/card.spec.php
@@ -6,6 +6,7 @@ use function Kahlan\expect;
 
 describe(\Dxw\GovPressBlocks\Blocks\Card::class, function () {
     beforeEach(function () {
+        allow('wp_parse_args')->toBeCalled();
         $this->card = new \Dxw\GovPressBlocks\Blocks\Card([]);
     });
 
@@ -47,13 +48,33 @@ describe(\Dxw\GovPressBlocks\Blocks\Card::class, function () {
     });
 
     describe('->render()', function () {
-        it('loads the default template', function () {
-            allow('dirname')->toBeCalled();
-            expect('dirname')->toBeCalled()->once()->with(\Kahlan\Arg::toBeA('string'), 2);
-            allow('load_template')->toBeCalled();
-            expect('load_template')->toBeCalled()->once();
-
-            $this->card->render();
+        context('no template was passed in the args', function () {
+            it('loads the default template', function () {
+                allow('wp_parse_args')->toBeCalled()->andReturn([
+                    'template' => ''
+                ]);
+                $this->card = new \Dxw\GovPressBlocks\Blocks\Card([]);
+                allow('dirname')->toBeCalled();
+                expect('dirname')->toBeCalled()->once()->with(\Kahlan\Arg::toBeA('string'), 2);
+                allow('load_template')->toBeCalled();
+                expect('load_template')->toBeCalled()->once();
+    
+                $this->card->render();
+            });
+        });
+        context('no template was passed in the args', function () {
+            it('loads the default template', function () {
+                allow('wp_parse_args')->toBeCalled()->andRun(function ($args, $defaultArgs) {
+                    return $args;
+                });
+                $this->card = new \Dxw\GovPressBlocks\Blocks\Card([
+                    'template' => 'foo.php'
+                ]);
+                allow('load_template')->toBeCalled();
+                expect('load_template')->toBeCalled()->once()->with('foo.php', false);
+    
+                $this->card->render();
+            });
         });
     });
 });

--- a/spec/factory.spec.php
+++ b/spec/factory.spec.php
@@ -6,6 +6,9 @@ describe('\Dxw\GovPressBlocks\Factory::class', function () {
     describe('::create()', function () {
         it('returns an instance of a block if it exists, and throws an exception if you try to create a block twice', function () {
             foreach (\Dxw\GovPressBlocks\Factory::BLOCKS as $blockName => $className) {
+                allow($className)->toBeOk();
+                allow($className)->toReceive('__construct');
+                allow($className)->toReceive('register');
                 $result = \Dxw\GovPressBlocks\Factory::create($blockName, []);
                 expect($result)->toBeAnInstanceOf($className);
             }

--- a/spec/factory.spec.php
+++ b/spec/factory.spec.php
@@ -1,0 +1,31 @@
+<?php
+
+use Kahlan\Plugin\Double;
+
+describe('\Dxw\GovPressBlocks\Factory::class', function () {
+    describe('::create()', function () {
+        it('returns an instance of a block if it exists, and throws an exception if you try to create a block twice', function () {
+            foreach (\Dxw\GovPressBlocks\Factory::BLOCKS as $blockName => $className) {
+                $result = \Dxw\GovPressBlocks\Factory::create($blockName, []);
+                expect($result)->toBeAnInstanceOf($className);
+            }
+            // Ideally this would be a separate test
+            // But can't find a way to stop the class persisting across tests
+            $closure = function () {
+                \Dxw\GovPressBlocks\Factory::create('card');
+            };
+            expect($closure)->toThrow(new Exception('GovPressBlock type already created: card'));
+        });
+
+        xit('passes the optional args array to the block constructor', function () {
+            // Can't find a way to create a double that correctly implements the iBlock interface
+        });
+
+        it('throws an exception if you try to new up a card type that does not exist', function () {
+            $closure = function () {
+                \Dxw\GovPressBlocks\Factory::create('foo', []);
+            };
+            expect($closure)->toThrow(new Exception('GovPressBlock type does not exist: foo'));
+        });
+    });
+});

--- a/src/Blocks/Card.php
+++ b/src/Blocks/Card.php
@@ -55,7 +55,6 @@ class Card implements iBlock
                     'default_value' => 'simple',
                     'return_format' => 'Value'
                 ])
-                ->addImage('image')
                 ->addLink('link')
                 ->addTextarea('description')
                 ->conditional('card_style', '==', 'full')                

--- a/src/Blocks/Card.php
+++ b/src/Blocks/Card.php
@@ -12,7 +12,10 @@ class Card implements iBlock
 
     public function __construct(array $args)
     {
-        $this->args = $args;
+        $defaults = [
+            'template' => ''
+        ];
+        $this->args = wp_parse_args($args, $defaults);
     }
 
     public function register()
@@ -57,7 +60,7 @@ class Card implements iBlock
                 ])
                 ->addLink('link')
                 ->addTextarea('description')
-                ->conditional('card_style', '==', 'full')                
+                ->conditional('card_style', '==', 'full')
                 ->setLocation('block', '==', 'acf/dxw-govpress-blocks-card');
 
             acf_add_local_field_group($fields->build());
@@ -66,6 +69,10 @@ class Card implements iBlock
 
     public function render()
     {
-        load_template(dirname(__DIR__, 2) . $this->templatePath, false);
+        if ($this->args['template'] == '') {
+            load_template(dirname(__DIR__, 2) . $this->templatePath, false);
+        } else {
+            load_template($this->args['template'], false);
+        }
     }
 }

--- a/src/Blocks/Card.php
+++ b/src/Blocks/Card.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Dxw\GovPressBlocks\Blocks;
+
+class Card implements iBlock
+{
+    private $args;
+
+    // Path to the default template for this block
+    // Relative to the root of this package
+    private $templatePath = '/templates/card.php';
+
+    public function __construct(array $args)
+    {
+        $this->args = $args;
+    }
+
+    public function register()
+    {
+        add_action('acf/init', [$this, 'registerBlock']);
+        add_action('acf/init', [$this, 'registerFields']);
+    }
+
+    public function registerBlock()
+    {
+        if (function_exists('acf_register_block_type')) {
+            acf_register_block_type([
+                'name'              => 'dxw-govpress-blocks-card',
+                'title'             => 'Content Card',
+                'render_callback'   => [$this, 'render'],
+                'mode'              => 'auto',
+                'category'          => 'common',
+                'icon'              => '<svg width="24" height="24" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path d="M13.029 8.793s0-5 3-5l-.058 5.835c0 .6-.4 1-1 1h-10c-.6 0-1-.4-1-1l.058-2.835c2 0 2.942 2.835 2.942 2.835s1.058-2.835 3.058-2.835c2 0 3 2 3 2ZM3.979 12.466h12v1.101h-12ZM2.307 11.265h15.152v.44H2.307Z"/><path d="M2.2 1h15.5c.7 0 1.3.6 1.3 1.2l.052 15.974c0 .7-.6 1.2-1.2 1.2h-15.6c-.6.1-1.2-.5-1.2-1.1L1 2.2C1 1.6 1.6 1 2.2 1ZM17 17.377V3H3v14.377Z"/><path d="M3.993 14.409h12l.018.408h-12ZM4.002 15.609h12l.018.408h-12Z"/></svg>',
+                'keywords'          => ['card', 'text'],
+                'supports'          => [
+                    'align' => false
+                ]
+            ]);
+        }
+    }
+
+    public function registerFields()
+    {
+        if (function_exists('acf_add_local_field_group')) {
+            $fields = new \StoutLogic\AcfBuilder\FieldsBuilder('dxw-govpress-blocks-card', [
+                'style' => 'seamless',
+            ]);
+            $fields
+                ->addButtonGroup('card_style', [
+                    'label'         => 'Card style',
+                    'choices'       => [
+                        'simple' => "Simple",
+                        'full' => "Full"
+                    ],
+                    'default_value' => 'simple',
+                    'return_format' => 'Value'
+                ])
+                ->addImage('image')
+                ->addLink('link')
+                ->addTextarea('description')
+                ->conditional('card_style', '==', 'full')                
+                ->setLocation('block', '==', 'acf/dxw-govpress-blocks-card');
+
+            acf_add_local_field_group($fields->build());
+        }
+    }
+
+    public function render()
+    {
+        load_template(dirname(__DIR__, 2) . $this->templatePath, false);
+    }
+}

--- a/src/Blocks/iBlock.php
+++ b/src/Blocks/iBlock.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Dxw\GovPressBlocks\Blocks;
+
+interface iBlock
+{
+    public function __construct(array $args);
+
+    public function register();
+}

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Dxw\GovPressBlocks;
+
+class Factory
+{
+    const BLOCKS = [
+        'card' => 'Dxw\GovPressBlocks\Blocks\Card'
+    ];
+
+    private static $registeredBlocks = [];
+
+    public static function create(string $blockName, array $args = [])
+    {
+        if (!array_key_exists($blockName, self::BLOCKS)) {
+            throw new \Exception('GovPressBlock type does not exist: ' . $blockName);
+        }
+        if (in_array($blockName, self::$registeredBlocks)) {
+            throw new \Exception('GovPressBlock type already created: ' . $blockName);
+        }
+        $block = self::BLOCKS[$blockName];
+        self::$registeredBlocks[] = $blockName;
+        $blockInstance = new $block($args);
+        $blockInstance->register();
+        return $blockInstance;
+    }
+}

--- a/templates/card.php
+++ b/templates/card.php
@@ -1,0 +1,2 @@
+<h1>Card template</h1>
+<p>To be populated</p>

--- a/templates/card.php
+++ b/templates/card.php
@@ -1,2 +1,28 @@
-<h1>Card template</h1>
-<p>To be populated</p>
+<?php
+
+$link = get_field('link');
+
+?>
+
+<article class="card card--full card--default-bg">
+  <div class="card__content">
+    <!-- CONTENT -->
+    <div class="card__text">
+
+      <!-- TITLE -->
+      <h3 class="govuk-heading-m">
+        <a class="card__link" href="<?php echo esc_url($link['url']) ?>" rel="bookmark"><?php echo wp_kses_post($link['title']) ?></a>
+      </h3>
+
+      <?php if (get_field('card_style') === 'full' && get_field('description')) : ?>
+      <!-- DESCRIPTION -->
+      <p class="card__description">
+        <?php echo wp_kses_post(get_field('description')) ?>
+      </p>
+      <?php endif; ?>
+    </div>
+    <!-- /.card__text -->
+    
+  </div>
+  <!-- /.card__content -->
+</article>


### PR DESCRIPTION
The intention of this repo is that it will become a library of reusable blocks for use in GovPress projects, that can be loaded directly into a theme using composer. This PR adds a basic card block, plus the supporting code for other blocks to be added using the same pattern in future.

Specifically, it:

* Uses a factory-like pattern, so devs will be able to register a block with a single call: `\Dxw\GovPressBlocks\Factory::create(string $blockType, array $optionalExtraConfig);`
* Adds the first `$blockType` of 'card'
* Adds a basic default front-end template for that card block
* Provides the option to override the default card template with a custom one.

The card is currently unstyled, but the intention is that future PRs will add styling partials that can be imported into a theme's SCSS. It's also expected that more fields may be added in future PRs (e.g. an image field, the option to toggle a date on the card)

Example of the card block in the editor:

![Screenshot 2022-07-29 at 15 32 03](https://user-images.githubusercontent.com/370665/181782465-8262b4fc-a6d9-40a7-bab0-bfbad0387c73.png)

Rendered in the front-end (currently just picking up the existing styles of the test theme):

![Screenshot 2022-07-29 at 15 32 42](https://user-images.githubusercontent.com/370665/181782571-981bb3f9-046c-4886-8d22-36499557d595.png)


## How to test

* Pick a relatively simple block-editor based project to clone locally (e.g. [BFI Blog](https://github.com/dxw/bfi-blog))
* Require this branch of the composer package in the theme: `composer require dxw/govpress-blocks:dev-feature/card-block`
* Add the following to the theme's `app/di.php` file:
   ```
   \Dxw\GovPressBlocks\Factory::create('card');
   ```
* A "Content card" block should now be available in the editor, and render (unstyled) in the front-end
* You should also be able to render a custom template for the card in the frontend, by doing:
   ```
   \Dxw\GovPressBlocks\Factory::create('card', [
     'template' => '/full/path/to/your/custom/template.php'
   );
   ```
   
   